### PR TITLE
Fix/use warnings

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/iceberg/iceberg.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/iceberg/iceberg.py
@@ -156,8 +156,8 @@ class IcebergSource(StatefulIngestionSourceBase):
                 )
                 pass
             except Exception as e:
-                self.report.report_failure("general", f"Failed to create workunit: {e}")
-                LOGGER.exception(
+                self.report.report_warning("general", f"Failed to create workunit: {e}")
+                LOGGER.warning(
                     f"Exception while processing table {dataset_path}, skipping it.",
                 )
 

--- a/metadata-ingestion/src/datahub/ingestion/source/iceberg/iceberg.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/iceberg/iceberg.py
@@ -156,6 +156,8 @@ class IcebergSource(StatefulIngestionSourceBase):
                 )
                 pass
             except Exception as e:
+                # This is a custom CCCS modification, when we complete CLDN-1784 we
+                # will be able to change this back to emit an exception instead of a warning
                 self.report.report_warning("general", f"Failed to create workunit: {e}")
                 LOGGER.warning(
                     f"Exception while processing table {dataset_path}, skipping it.",


### PR DESCRIPTION
This PR is to modify the Iceberg source so that instead of throwing an error when a work unit cannot be created, it instead just generates a warning