### PR TITLE
Added launch configuration for a debugger in the devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,51 +1,76 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
 // https://github.com/microsoft/vscode-dev-containers/tree/v0.177.0/containers/java
 {
-	"name": "DataHub",
-	"build": {
-		"dockerfile": "Dockerfile"
-	},
-	"runArgs": [
-		"--init",
-		"--privileged"
-	],
-	"initializeCommand": "mkdir -p ${env:HOME}/scratch && mkdir -p ${env:HOME}/.devcontainers/datahub-caches/dot-local && mkdir -p ${env:HOME}/.devcontainers/datahub-caches/dot-cache && mkdir -p ${env:HOME}/.devcontainers/datahub-caches/dot-gradle && touch ${env:HOME}/.devcontainers/datahub-bashhistory && WORK_DIR=${localWorkspaceFolder}/.devcontainer/.work && rm -rf $WORK_DIR && mkdir -p $WORK_DIR && cp /etc/ssl/certs/ssl_proxy_corp_cse-cst_gc_ca.pem $WORK_DIR/ssl_proxy_corp_cse-cst_gc_ca.crt",
-	"mounts": [
-		"source=${env:HOME}/.ssh/agent.sock,target=/usr/local/share/ssh-agent.sock,type=bind",
-		"source=${env:HOME}/.devcontainers/datahub-bashhistory,target=/usr/local/share/bash_history,type=bind",
-		"source=${env:HOME}/scratch,target=${containerWorkspaceFolder}/scratch,type=bind",
-		"source=datahub-dind-var-lib-docker,target=/var/lib/docker,type=volume",
-		"source=${env:HOME}/.devcontainers/datahub-caches/dot-local,target=/home/vscode/.local,type=bind",
-		"source=${env:HOME}/.devcontainers/datahub-caches/dot-cache,target=/home/vscode/.cache,type=bind",
-		"source=${env:HOME}/.devcontainers/datahub-caches/dot-gradle,target=/home/vscode/.gradle,type=bind"
-	],
-	"remoteEnv": {
-		"SSH_AUTH_SOCK": "/usr/local/share/ssh-agent.sock",
-		"HISTFILE": "/usr/local/share/bash_history",
-		"PROMPT_COMMAND": "history -a"
-	},
-	"workspaceMount": "source=${localWorkspaceFolder}/..,target=${containerWorkspaceFolder}/repositories,type=bind,consistency=cached",
-	"workspaceFolder": "/workspace",
-	// Set *default* container specific settings.json values on container create.
-	"settings": {
-		"terminal.integrated.cwd": "${containerWorkspaceFolder}/repositories/datahub",
-		"terminal.integrated.defaultProfile.linux": "bash",
-		"java.import.gradle.java.home": "/docker-java-home",
-		"java.jdt.ls.java.home": "/docker-java-home"
-	},
-	// Add the IDs of extensions you want installed when the container is created.
-	"extensions": [
-		"eamodio.gitlens",
-		"ms-azuretools.vscode-docker",
-		"ms-python.python",
-		"ms-vscode.azure-account",
-		"ms-vscode.azurecli",
-		"naco-siren.gradle-language",
-		"vscjava.vscode-gradle"
-	],
-	"overrideCommand": false,
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [],
-	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
-	"remoteUser": "vscode"
+    "name": "DataHub",
+    "build": {
+        "dockerfile": "Dockerfile"
+    },
+    "runArgs": [
+        "--init",
+        "--privileged"
+    ],
+    "initializeCommand": "mkdir -p ${env:HOME}/scratch && mkdir -p ${env:HOME}/.devcontainers/datahub-caches/dot-local && mkdir -p ${env:HOME}/.devcontainers/datahub-caches/dot-cache && mkdir -p ${env:HOME}/.devcontainers/datahub-caches/dot-gradle && touch ${env:HOME}/.devcontainers/datahub-bashhistory && WORK_DIR=${localWorkspaceFolder}/.devcontainer/.work && rm -rf $WORK_DIR && mkdir -p $WORK_DIR && cp /etc/ssl/certs/ssl_proxy_corp_cse-cst_gc_ca.pem $WORK_DIR/ssl_proxy_corp_cse-cst_gc_ca.crt",
+    "mounts": [
+        "source=${env:HOME}/.ssh/agent.sock,target=/usr/local/share/ssh-agent.sock,type=bind",
+        "source=${env:HOME}/.devcontainers/datahub-bashhistory,target=/usr/local/share/bash_history,type=bind",
+        "source=${env:HOME}/scratch,target=${containerWorkspaceFolder}/scratch,type=bind",
+        "source=datahub-dind-var-lib-docker,target=/var/lib/docker,type=volume",
+        "source=${env:HOME}/.devcontainers/datahub-caches/dot-local,target=/home/vscode/.local,type=bind",
+        "source=${env:HOME}/.devcontainers/datahub-caches/dot-cache,target=/home/vscode/.cache,type=bind",
+        "source=${env:HOME}/.devcontainers/datahub-caches/dot-gradle,target=/home/vscode/.gradle,type=bind"
+    ],
+    "remoteEnv": {
+        "SSH_AUTH_SOCK": "/usr/local/share/ssh-agent.sock",
+        "HISTFILE": "/usr/local/share/bash_history",
+        "PROMPT_COMMAND": "history -a"
+    },
+    "workspaceMount": "source=${localWorkspaceFolder}/..,target=${containerWorkspaceFolder}/repositories,type=bind,consistency=cached",
+    "workspaceFolder": "/workspace",
+    // Set *default* container specific settings.json values on container create.
+    "settings": {
+        "terminal.integrated.cwd": "${containerWorkspaceFolder}/repositories/datahub",
+        "terminal.integrated.defaultProfile.linux": "bash",
+        "java.import.gradle.java.home": "/docker-java-home",
+        "java.jdt.ls.java.home": "/docker-java-home",
+        "launch": {
+            "configurations": [
+                {
+                    "name": "datahub ingest",
+                    "type": "python",
+                    "request": "launch",
+                    "program": "${workspaceRoot}/repositories/datahub/smoke-test/venv/bin/datahub",
+                    // "args": ["ingest", "-c", "${workspaceRoot}/scratch/recipes/dbt_test.yaml"],
+                    "args": ["ingest", "-c", "${file}"],
+                    "cwd": "${workspaceRoot}/repositories/datahub/metadata-ingestion",
+                    "envFile": "${workspaceFolder}/scratch/datahub/.env",
+                    "console": "integratedTerminal",
+                    "justMyCode": false
+                },
+                {
+                    "name": "Python: Debug Tests",
+                    "type": "python",
+                    "request": "launch",
+                    "program": "${file}",
+                    "purpose": ["debug-test"],
+                    "console": "integratedTerminal",
+                    "justMyCode": false
+                }
+            ]
+          }
+        },
+    // Add the IDs of extensions you want installed when the container is created.
+    "extensions": [
+        "eamodio.gitlens",
+        "ms-azuretools.vscode-docker",
+        "ms-python.python",
+        "ms-vscode.azure-account",
+        "ms-vscode.azurecli",
+        "naco-siren.gradle-language",
+        "vscjava.vscode-gradle"
+    ],
+    "overrideCommand": false,
+    // Use 'forwardPorts' to make a list of ports inside the container available locally.
+    // "forwardPorts": [],
+    // Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+    "remoteUser": "vscode"
 }


### PR DESCRIPTION
This PR adds a configuration to the devcontainer which allows you to debug any given ingestion source. Simply open a recipe you would like to run, and select the play button next to the `datahub ingestion` debug option.

-Also changed the tabs to spaces in the devcontainer.json file