### PR TITLE
Turned off 'INFO' level logging

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/iceberg/iceberg.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/iceberg/iceberg.py
@@ -75,7 +75,8 @@ from datahub.metadata.schema_classes import (
 )
 
 LOGGER = logging.getLogger(__name__)
-logging.disable(logging.INFO)
+http_logging_policy_logger = logging.getLogger("azure.core.pipeline.policies.http_logging_policy")  # CCCS Change
+http_logging_policy_logger.setLevel(logging.WARNING)    # CCCS Change
 
 _all_atomic_types = {
     BooleanType: "boolean",

--- a/metadata-ingestion/src/datahub/ingestion/source/iceberg/iceberg.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/iceberg/iceberg.py
@@ -75,6 +75,7 @@ from datahub.metadata.schema_classes import (
 )
 
 LOGGER = logging.getLogger(__name__)
+logging.disable(logging.INFO)
 
 _all_atomic_types = {
     BooleanType: "boolean",


### PR DESCRIPTION
This PR removes the unnecessary 'INFO' level logs from the Iceberg ingestion source